### PR TITLE
📝 docs(use-cases): update error responses

### DIFF
--- a/json.txt
+++ b/json.txt
@@ -239,7 +239,10 @@ ShopComp Use Cases JSON State Representations
           "code": 200
         }
     400 on failure: { 
-      "error": "Unable to retrieve shopping lists for the specified user"
+      "error": "User does not exist"
+    }
+    400 on failure: {
+      "error": "Not authenticated"
     }
 ----------------------------------------------------------------- Nikita
 /remove-shopping-list
@@ -270,7 +273,13 @@ ShopComp Use Cases JSON State Representations
           "code": 200
         }
     400 on failure: { 
-      "error": "Unable to remove the specified shopping list"
+      "error": "User does not exist"
+    }
+    400 on failure: {
+      "error": "Shopping list does not exist"
+    }
+    400 on failure: {
+      "error": "Not authenticated or not authorized to delete this list"
     }
 ----------------------------------------------------------------- Nikita
 /create-shopping-list
@@ -287,7 +296,13 @@ ShopComp Use Cases JSON State Representations
           "code": 200
         }
     400 on failure: { 
-      "error": "Unable to create shopping list"
+      "error": "User does not exist"
+    }
+    400 on failure: {
+      "error": "Shopping list with this name already exists"
+    }
+    400 on failure: {
+      "error": "Not authenticated or not authorized to create a list for this user"
     }
 ----------------------------------------------------------------- Nikita
 /add-to-shopping-list
@@ -322,7 +337,19 @@ ShopComp Use Cases JSON State Representations
           "code": 200
         }
     400 on failure: { 
-      "error": "Unable to add item to the shopping list"
+      "error": "User does not exist"
+    }
+    400 on failure: {
+      "error": "Shopping list does not exist"
+    }
+    400 on failure: {
+      "error": "Not authenticated or not authorized to modify this list"
+    }
+    400 on failure: {
+      "error": "Item already exists in the shopping list"
+    }
+    400 on failure: {
+      "error": "Invalid item data"
     }
 ----------------------------------------------------------------- Nikita
 /remove-from-shopping-list
@@ -345,7 +372,18 @@ ShopComp Use Cases JSON State Representations
           "message": "Item removed successfully from the shopping list",
           "code": 200
         }
-	400 on failure: { "error": "Unable to remove item from the shopping list" }
+	400 on failure: {
+    "error": "User does not exist" 
+  }
+  400 on failure: {
+    "error": "Shopping list does not exist" 
+  }
+  400 on failure: {
+    "error": "Not authenticated or not authorized to modify this list" 
+  }
+  400 on failure: {
+    "error": "Item does not exist in the shopping list" 
+  }
 ----------------------------------------------------------------- Harrison
 /list-store-chains
     GET: {}


### PR DESCRIPTION
Add explicit 400 failure variants (e.g. "User does not exist", "Not authenticated", "Shopping list does not exist", "Item already exists", "Invalid item data") across shopping-list related use-case examples. Endpoints updated: get/create/remove shopping lists and add/ remove items. Improves documentation clarity for client handling.

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQB0fi2iJCmzT5BE0EVyuauxyyLg8qJwfWkJQ&s)